### PR TITLE
RawTX and block headers added to Explorer UI

### DIFF
--- a/src/data/mainnet-routes.json
+++ b/src/data/mainnet-routes.json
@@ -118,6 +118,15 @@
             "4db095f34d632a4daf942142c291f1f2abb5ba2e1ccac919d85bdc2f671fb251"
           ]
         }
+      },
+      {
+        "type": "get",
+        "shortDescription": "Get 'count' block headers starting at a height",
+        "detailedDescription": "Returns an array with block headers starting at the block height",
+        "endpoint": "/v3/electrumx/block/headers/",
+        "parameters": "42?count=2",
+        "parametersName": "Height and count",
+        "parameterDescription": "count blocks, starting at height"
       }
     ]
   },

--- a/src/data/mainnet-routes.json
+++ b/src/data/mainnet-routes.json
@@ -95,6 +95,29 @@
             "bitcoincash:qr69kyzha07dcecrsvjwsj4s6slnlq4r8c30lxnur3"
           ]
         }
+      },
+      {
+        "type": "get",
+        "shortDescription": "Get transaction details for a TXID",
+        "detailedDescription": "Returns an object with details for the transaction - inputs, outputs etc.",
+        "endpoint": "/v3/electrumx/tx/data/",
+        "parameters": "4db095f34d632a4daf942142c291f1f2abb5ba2e1ccac919d85bdc2f671fb251",
+        "parametersName": "TXID",
+        "parameterDescription": "Transaction ID"
+      },
+      {
+        "type": "post",
+        "shortDescription": "Get transaction details for an array of TXIDs",
+        "detailedDescription": "Returns an array of objects. Each object contains transaction details for one TXID. Up to 20 TXIDs per request.",
+        "endpoint": "/v3/electrumx/tx/data",
+        "parametersName": "TXIDs",
+        "parameterDescription": "Array of transaction IDs",
+        "body": {
+          "txids": [
+            "4db095f34d632a4daf942142c291f1f2abb5ba2e1ccac919d85bdc2f671fb251",
+            "4db095f34d632a4daf942142c291f1f2abb5ba2e1ccac919d85bdc2f671fb251"
+          ]
+        }
       }
     ]
   },

--- a/src/data/testnet-routes.json
+++ b/src/data/testnet-routes.json
@@ -118,6 +118,15 @@
             "76d2ee0ebd8b978742f6478ff9a12f478c34e4cee0a2b919059101d961bd01ee"
           ]
         }
+      },
+      {
+        "type": "get",
+        "shortDescription": "Get 'count' block headers starting at a height",
+        "detailedDescription": "Returns an array with block headers starting at the block height",
+        "endpoint": "/v3/electrumx/block/headers/",
+        "parameters": "42?count=2",
+        "parametersName": "Height and count",
+        "parameterDescription": "count blocks, starting at height"
       }
     ]
   },

--- a/src/data/testnet-routes.json
+++ b/src/data/testnet-routes.json
@@ -95,6 +95,29 @@
             "bchtest:qz35h5mfa8w2pqma2jq06lp7dnv5fxkp2svtllzmlf"
           ]
         }
+      },
+      {
+        "type": "get",
+        "shortDescription": "Get transaction details for a TXID",
+        "detailedDescription": "Returns an object with details for the transaction - inputs, outputs etc.",
+        "endpoint": "/v3/electrumx/tx/data/",
+        "parameters": "76d2ee0ebd8b978742f6478ff9a12f478c34e4cee0a2b919059101d961bd01ee",
+        "parametersName": "TXID",
+        "parameterDescription": "Transaction ID"
+      },
+      {
+        "type": "post",
+        "shortDescription": "Get transaction details for an array of TXIDs",
+        "detailedDescription": "Returns an array of objects. Each object contains transaction details for one TXID. Up to 20 TXIDs per request.",
+        "endpoint": "/v3/electrumx/tx/data",
+        "parametersName": "TXIDs",
+        "parameterDescription": "Array of transaction IDs",
+        "body": {
+          "txids": [
+            "76d2ee0ebd8b978742f6478ff9a12f478c34e4cee0a2b919059101d961bd01ee",
+            "76d2ee0ebd8b978742f6478ff9a12f478c34e4cee0a2b919059101d961bd01ee"
+          ]
+        }
       }
     ]
   },


### PR DESCRIPTION
Combined both issues in one PR for easy no-conflicts merging (because they changing same files), but separated them in different commits for easy checking.

* Issue #48 - commit# f684905

`mainnet` and `testnet` JSON files updated. Seems by default `verbose = true`  in the `bch-js` implementation, so this parameter is not added to the URL

 * Issue #50 - commit# 41dee62

`mainnet` and `testnet` JSON files updated. GET method only. Small detail here: in the JSON file, for the other methods, when there are several URL parameters, they are listed _as one, string type_  - example` 'url/10111?bbb=2'` Is this the right way or there is some better way?

