### PR TITLE
Switching to free tier API endpoints

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -6,5 +6,5 @@ APISERVER=http://localhost:3000/v3/
 #APISERVER=https://api.fullstack.cash/v3/
 #AUTHSERVER=https://auth.fullstack.cash
 
-MAINNETSERVER=https://api.fullstack.cash
-TESTNETSERVER=https://tapi.fullstack.cash
+MAINNETSERVER=https://free-main.fullstack.cash
+TESTNETSERVER=https://free-test.fullstack.cash

--- a/.env.production
+++ b/.env.production
@@ -4,5 +4,5 @@
 APISERVER=https://api.fullstack.cash/v3/
 AUTHSERVER=https://auth.fullstack.cash
 
-MAINNETSERVER=https://api.fullstack.cash
-TESTNETSERVER=https://tapi.fullstack.cash
+MAINNETSERVER=https://free-main.fullstack.cash
+TESTNETSERVER=https://free-test.fullstack.cash

--- a/src/data/mainnet-routes.json
+++ b/src/data/mainnet-routes.json
@@ -2,7 +2,7 @@
   {
     "name": "ElectrumX / Fulcrum",
     "description": "Query ElectrumX Indexer Network",
-    "docUrl": "https://api.fullstack.cash/docs/#api-ElectrumX_/_Fulcrum",
+    "docUrl": "https://free-main.fullstack.cash/docs/#api-ElectrumX_/_Fulcrum",
     "endpoints": [
       {
         "type": "get",
@@ -133,7 +133,7 @@
   {
     "name": "BlockBook",
     "description": "Get BlockBook info",
-    "docUrl": "https://api.fullstack.cash/docs/#api-Blockbook",
+    "docUrl": "https://free-main.fullstack.cash/docs/#api-Blockbook",
     "endpoints": [
       {
         "type": "get",
@@ -209,7 +209,7 @@
   {
     "name": "Blockchain",
     "description": "Get Blockchain info",
-    "docUrl": "https://api.fullstack.cash/docs/#api-Blockchain",
+    "docUrl": "https://free-main.fullstack.cash/docs/#api-Blockchain",
     "endpoints": [
       {
         "type": "get",
@@ -348,7 +348,7 @@
   {
     "name": "Control",
     "description": "Get Control info",
-    "docUrl": "https://api.fullstack.cash/docs/#api-Control",
+    "docUrl": "https://free-main.fullstack.cash/docs/#api-Control",
     "endpoints": [
       {
         "type": "get",
@@ -361,7 +361,7 @@
   {
     "name": "Encryption",
     "description": "Bitcoin-based Encryption Tools",
-    "docUrl": "https://api.fullstack.cash/docs/#api-Encryption",
+    "docUrl": "https://free-main.fullstack.cash/docs/#api-Encryption",
     "endpoints": [
       {
         "type": "get",
@@ -377,7 +377,7 @@
   {
     "name": "Mining",
     "description": "Get Mining Info",
-    "docUrl": "https://api.fullstack.cash/docs/#api-Mining",
+    "docUrl": "https://free-main.fullstack.cash/docs/#api-Mining",
     "endpoints": [
       {
         "type": "get",
@@ -399,7 +399,7 @@
   {
     "name": "Raw Transaction",
     "description": "Get Raw Transaction Info",
-    "docUrl": "https://api.fullstack.cash/docs/#api-Raw_Transaction",
+    "docUrl": "https://free-main.fullstack.cash/docs/#api-Raw_Transaction",
     "endpoints": [
       {
         "type": "post",
@@ -498,7 +498,7 @@
   {
     "name": "SLP",
     "description": "Get SLP info",
-    "docUrl": "https://api.fullstack.cash/docs/#api-SLP",
+    "docUrl": "https://free-main.fullstack.cash/docs/#api-SLP",
     "endpoints": [
       {
         "type": "get",

--- a/src/data/testnet-routes.json
+++ b/src/data/testnet-routes.json
@@ -2,7 +2,7 @@
   {
     "name": "ElectrumX / Fulcrum",
     "description": "Query ElectrumX Indexer Network",
-    "docUrl": "https://api.fullstack.cash/docs/#api-ElectrumX_/_Fulcrum",
+    "docUrl": "https://free-test.fullstack.cash/docs/#api-ElectrumX_/_Fulcrum",
     "endpoints": [
       {
         "type": "get",
@@ -133,7 +133,7 @@
   {
     "name": "BlockBook",
     "description": "Get Blockbook Info",
-    "docUrl": "https://api.fullstack.cash/docs/#api-Blockbook",
+    "docUrl": "https://free-test.fullstack.cash/docs/#api-Blockbook",
     "endpoints": [
       {
         "type": "get",
@@ -209,7 +209,7 @@
   {
     "name": "Blockchain",
     "description": "Get Blockchain info",
-    "docUrl": "https://api.fullstack.cash/docs/#api-Blockchain",
+    "docUrl": "https://free-test.fullstack.cash/docs/#api-Blockchain",
     "endpoints": [
       {
         "type": "get",
@@ -348,7 +348,7 @@
   {
     "name": "Control",
     "description": "Get Control info",
-    "docUrl": "https://api.fullstack.cash/docs/#api-Control",
+    "docUrl": "https://free-test.fullstack.cash/docs/#api-Control",
     "endpoints": [
       {
         "type": "get",
@@ -361,7 +361,7 @@
   {
     "name": "Encryption",
     "description": "Bitcoin-based Encryption Tools",
-    "docUrl": "https://api.fullstack.cash/docs/#api-Encryption",
+    "docUrl": "https://free-test.fullstack.cash/docs/#api-Encryption",
     "endpoints": [
       {
         "type": "get",
@@ -377,7 +377,7 @@
   {
     "name": "Mining",
     "description": " Get Mining Info",
-    "docUrl": "https://api.fullstack.cash/docs/#api-Mining",
+    "docUrl": "https://free-test.fullstack.cash/docs/#api-Mining",
     "endpoints": [
       {
         "type": "get",
@@ -399,7 +399,7 @@
   {
     "name": "Raw Transaction",
     "description": "Get Raw Transaction Info",
-    "docUrl": "https://api.fullstack.cash/docs/#api-Raw_Transaction",
+    "docUrl": "https://free-test.fullstack.cash/docs/#api-Raw_Transaction",
     "endpoints": [
       {
         "type": "post",
@@ -498,7 +498,7 @@
   {
     "name": "Get SLP Info",
     "description": ".",
-    "docUrl": "https://api.fullstack.cash/docs/#api-SLP",
+    "docUrl": "https://free-test.fullstack.cash/docs/#api-SLP",
     "endpoints": [
       {
         "type": "get",


### PR DESCRIPTION
Issue #56

Changed the routes and environment settings to use `free-main` and `free-test` API endpoints.
Markdown file with not-working endpoints is attached:

[non_working_md.txt](https://github.com/Permissionless-Software-Foundation/jwt-bch-frontend/files/5292030/non_working_md.txt) - rename to `.md`.

 Some of them maybe not working only on my environment - _"Network error: Could not communicate with full node or other external service."_ message (error code 503)